### PR TITLE
Change url to official and add GitHub action to test build the package.

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -19,9 +19,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r requirements_dev.txt
         pip install setuptools wheel twine
-    - name: Run tests
-      run: |
-        tox
     - name: Build the package
       run: |
         python setup.py sdist bdist_wheel

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -19,3 +19,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r requirements_dev.txt
         pip install setuptools wheel twine
+    - name: Build the package
+      run: |
+        python setup.py sdist bdist_wheel

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -21,8 +21,6 @@ jobs:
         pip install setuptools wheel twine
     - name: Run tests
       run: |
-        flake8 pyscihub tests
-        python setup.py test
         tox
     - name: Build the package
       run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -19,6 +19,11 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r requirements_dev.txt
         pip install setuptools wheel twine
+    - name: Run tests
+      run: |
+        flake8 pyscihub tests
+        python setup.py test
+        tox
     - name: Build the package
       run: |
         python setup.py sdist bdist_wheel

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,0 +1,21 @@
+name: Build Python Package
+    
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements_dev.txt
+        pip install setuptools wheel twine

--- a/pyscihub/cli.py
+++ b/pyscihub/cli.py
@@ -29,7 +29,7 @@ def cli(ctx, output, verbose):
 @click.argument("file_path", type=click.Path(exists=True))
 @click.pass_context
 def make_file(ctx, file_path):
-    scihub = SciHub("https://sci-hub.se", ctx.obj["OUTPUT"])
+    scihub = SciHub("https://sci-hub.ru", ctx.obj["OUTPUT"])
 
     # open file
     with open(file_path, "r") as f:
@@ -42,7 +42,7 @@ def make_file(ctx, file_path):
 @click.argument("query", type=str)
 @click.pass_context
 def make_query(ctx, query):
-    scihub = SciHub("https://sci-hub.se", ctx.obj["OUTPUT"])
+    scihub = SciHub("https://sci-hub.ru", ctx.obj["OUTPUT"])
     scihub.download(query)
 
 


### PR DESCRIPTION
Using the power of GitHub action I added action as `CI` to test on pushes and PRs. I tried to include the tests and wanted to make sure that I passed but already tests doesn't work even on original code. but it can be added to the action easily. 

Also included in this PR is that I changed the sci-hub url to the latest available globally as `.se` is blocked in some countries. 


Note: There are a lot of mirror urls that would break funcationality and even alexandra is not happy about them. see [here](https://twitter.com/ringo_ring/status/1431376651691114501). As 3rd party mirrors usually change bitcoin donation wallet number available on the site. 

